### PR TITLE
Add workdir and GO111MODULE to work with go get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,13 @@ install:
   - go mod download
 
 script:
-  - go build ./cmd/gomodproxy
+  - go build ./cmd/gomodproxy  
   - go test -v ./...
+  - echo "module gomodproxy" > go.empty.mod
 
 after_success:
   - mkdir gomods
-  - printf 'FROM scratch\nADD gomodproxy /\nADD gomods /\nCMD ["/gomodproxy"]' > Dockerfile
+  - printf 'FROM scratch\nENV GO111MODULE=on\nADD gomodproxy /\nADD gomods /\nADD go.empty.mod /gomods/go.mod\nWORKDIR /gomods\nCMD ["/gomodproxy"]' > Dockerfile
   - docker build -t "sixtlabs/gomodproxy-slim:latest" .
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker push "sixtlabs/gomodproxy-slim:latest"
@@ -22,7 +23,7 @@ after_success:
       docker tag sixtlabs/gomodproxy-slim:latest sixtlabs/gomodproxy-slim:$TAG;
       docker push sixtlabs/gomodproxy-slim:$TAG;
     fi
-  - printf 'FROM golang\nADD gomodproxy /\nADD gomods /\nCMD ["/gomodproxy"]' > Dockerfile
+  - printf 'FROM golang\nENV GO111MODULE=on\nADD gomodproxy /\nADD gomods /\nADD go.empty.mod /gomods/go.mod\nWORKDIR /gomods\nCMD ["/gomodproxy"]' > Dockerfile
   - docker build -t "sixtlabs/gomodproxy:latest" .
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker push "sixtlabs/gomodproxy:latest"


### PR DESCRIPTION
To run **go get** (-vcs flag) we need set up:

- env variable **GO111MODULE=on**
- use work dir other than $GOPATH (by default - /go) 
- initialized **go.mod** in current work directory